### PR TITLE
Rename package specs & retract v1.3.0 tag

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,3 +5,5 @@ go 1.18
 require github.com/opencontainers/image-spec v1.0.2
 
 require github.com/opencontainers/go-digest v1.0.0 // indirect
+
+retract v1.3.0 // Package github.com/moby/docker-image-spec/specs-go has the wrong package name.

--- a/specs-go/version.go
+++ b/specs-go/version.go
@@ -1,4 +1,4 @@
-package v1
+package specs
 
 const (
 	Version      = "v1.3"


### PR DESCRIPTION
The package at package path github.com/moby/docker-image-spec/specs-go was assigned the package name `v1`. It is supposed to have the package name `specs` to mirror the name of the
github.com/opencontainers/image-spec/specs-go package, but this mistake was not caught until after stable module versions were tagged. Fix the package name and retract all the existing module versions.